### PR TITLE
Add requestPrehandler to api?

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,10 @@ var util = require('util');
 var AngularBridge = function(app, options) {
   this.app = app;
   this.options = _.extend({
-    urlPrefix: '/'
+    urlPrefix: '/',
+    requestPrehandler: function(req, res, next) {
+    	next();
+    }
   }, options || {});
   this.resources = [ ];
   this.registerRoutes();
@@ -26,18 +29,18 @@ module.exports = exports = AngularBridge;
  * Registers all REST routes with the provided `app` object.
  */
 AngularBridge.prototype.registerRoutes = function() {
-  this.app.all(this.options.urlPrefix + ':resourceName', this.collection());
-  this.app.get(this.options.urlPrefix + ':resourceName', this.collectionGet());
-  this.app.post(this.options.urlPrefix + ':resourceName', this.collectionPost());
+  this.app.all(this.options.urlPrefix + ':resourceName', this.options.requestPrehandler, this.collection());
+  this.app.get(this.options.urlPrefix + ':resourceName', this.options.requestPrehandler, this.collectionGet());
+  this.app.post(this.options.urlPrefix + ':resourceName', this.options.requestPrehandler, this.collectionPost());
   
-  this.app.all(this.options.urlPrefix + ':resourceName/:id', this.entity());
-  this.app.get(this.options.urlPrefix + ':resourceName/:id', this.entityGet());
+  this.app.all(this.options.urlPrefix + ':resourceName/:id', this.options.requestPrehandler, this.entity());
+  this.app.get(this.options.urlPrefix + ':resourceName/:id', this.options.requestPrehandler, this.entityGet());
 
   // You can POST or PUT to update data
-  this.app.post(this.options.urlPrefix + ':resourceName/:id', this.entityPut());
-  this.app.put(this.options.urlPrefix + ':resourceName/:id', this.entityPut());
+  this.app.post(this.options.urlPrefix + ':resourceName/:id', this.options.requestPrehandler, this.entityPut());
+  this.app.put(this.options.urlPrefix + ':resourceName/:id', this.options.requestPrehandler, this.entityPut());
 
-  this.app.delete(this.options.urlPrefix + ':resourceName/:id', this.entityDelete());
+  this.app.delete(this.options.urlPrefix + ':resourceName/:id', this.options.requestPrehandler, this.entityDelete());
 };
 
 AngularBridge.prototype.addResource = function(resource_name, model, options) {


### PR DESCRIPTION
I want this change so I can add logic as a consumer of angular-bridge to make sure the user hitting the endpoint is authorized to hit the endpoint. So for me, this change is for authentication purposes. But this simple change could have other use cases as well...
Notes:
- This is backward compatible (nobody will need to change anything to upgrade to this version)
- I used the name requestPrehandler because I thought that was the most descriptive of what it does. Even though the main value I can see is for security purposes, there are other use cases so I didn't want to use the name "authorize" or something like that.
- I toyed around with the idea of having the option be resource for resource... Maybe that would be the better way to go about doing this (maybe I'll submit another pull request for that method as well). I opted out of that for simplicity's sake. However, it may be easier for consumers of this api to add a requestPrehandler on a per resource basis... Thoughts?

I'm happy to accept changes to style and/or method.
