### PR TITLE
Added requestPrehandler to each resource rather than the requests.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,11 @@ AngularBridge.prototype.addResource = function(resource_name, model, options) {
   var resource = { 
     resource_name: resource_name, 
     model: model,
-    options : options || null
+    options: _.extend({
+      requestPrehandler: function(req, res, next) {
+        next();
+      }
+    }, options || {})
   };
 
   this.resources.push(resource);
@@ -77,8 +81,9 @@ AngularBridge.prototype.redirect = function (address, req, res, next) {
  */
 AngularBridge.prototype.collection = function() { 
   return _.bind(function(req, res, next) {
-    req.resource = this.getResource(req.params.resourceName);
-    return next();
+    var resource = this.getResource(req.params.resourceName);
+    req.resource = resource;
+    return resource.requestPrehandler(req, res, next);
   }, this); 
 };
 
@@ -183,30 +188,34 @@ AngularBridge.prototype.epureRequest = function(req, resource) {
  */
 AngularBridge.prototype.entity = function() { 
   return _.bind(function(req, res, next) {
-    if (!(req.resource = this.getResource(req.params.resourceName))) { next(); return; }
-    
-    var hidden_fields = this.generateHiddenFields(req.resource);
+    var resource = this.getResource(req.params.resourceName);
+    req.resource = resource;
+    return resource.requestPrehandler(req, res, function() {
+      if (!(req.resource = this.getResource(req.params.resourceName))) { next(); return; }
 
-    //
-    // select({_id : false}) invert the select process (hidde the _id field)
-    //
-    var query = req.resource.model.findOne({ _id: req.params.id }).select(hidden_fields);
-    
-    query.exec(function(err, doc) {
-      if (err) {
-	return res.send({
-	  success : false, 
-	  err : util.inspect(err)
-	});
-      }
-      else if (doc === null) {
-	return res.send({
-	  success : false, 
-	  err : 'Record not found'
-	});
-      }
-      req.doc = doc;
-      return next();
+      var hidden_fields = this.generateHiddenFields(req.resource);
+
+      //
+      // select({_id : false}) invert the select process (hidde the _id field)
+      //
+      var query = req.resource.model.findOne({ _id: req.params.id }).select(hidden_fields);
+
+      query.exec(function(err, doc) {
+        if (err) {
+          return res.send({
+	    success : false, 
+	    err : util.inspect(err)
+	  });
+        }
+        else if (doc === null) {
+	  return res.send({
+	    success : false, 
+	    err : 'Record not found'
+	  });
+        }
+        req.doc = doc;
+        return next();
+      });
     });
   }, this); 
 };


### PR DESCRIPTION
This method allows the consumer of the angular-bridge api to add an option for prehandling the requests. Better than adding a single prehandler to all requests I think.
